### PR TITLE
Fix #79 - Use CSS icons instead of inlined SVGs to improve performance, reduce duplication and improve DX

### DIFF
--- a/frontend/astro.config.js
+++ b/frontend/astro.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from 'astro/config'
 import sitemap from '@astrojs/sitemap'
 import svelte from '@astrojs/svelte'
 import tailwind from '@tailwindcss/vite'
-import Icons from 'unplugin-icons/vite'
 
 const site = 'https://www.allerthsbageri.se'
 
@@ -21,13 +20,7 @@ export default defineConfig({
     resolve: {
       conditions: ['browser'],
     },
-    plugins: [
-      tailwind(),
-      // NOTE: Allow using icons in both Svelte and Astro components
-      // Workaround for https://github.com/unplugin/unplugin-icons/issues/253
-      Icons({ compiler: 'svelte' }),
-      Icons({ compiler: 'astro' }),
-    ],
+    plugins: [tailwind()],
   },
   prefetch: {
     prefetchAll: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@iconify-json/game-icons": "^1.2.3",
     "@iconify-json/lucide": "^1.2.69",
+    "@iconify/tailwind4": "^1.0.6",
     "@internationalized/date": "^3.10.0",
     "@types/node": "^24.7.1",
     "bits-ui": "^2.11.5",
@@ -41,8 +42,7 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^3.1.1",
-    "tw-animate-css": "^1.4.0",
-    "unplugin-icons": "^22.4.2"
+    "tw-animate-css": "^1.4.0"
   },
   "prettier": {
     "tabWidth": 2,

--- a/frontend/src/components/booking-form/booking-footer.svelte
+++ b/frontend/src/components/booking-form/booking-footer.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import LucideChevronLeft from 'virtual:icons/lucide/chevron-left'
-  import LucideChevronRight from 'virtual:icons/lucide/chevron-right'
   import { buttonVariants } from '$components/ui/button'
   import { cn } from '$lib/utils'
   import { bookingContext } from './context'
@@ -25,7 +23,7 @@
           'justify-self-start',
           buttonVariants({ variant: 'outline', size: 'lg' }),
         ])}
-        ><LucideChevronLeft class="size-4" aria-hidden="true" /><span
+        ><span class="i-[lucide--chevron-left] size-4"></span><span
           >Tillbaka</span
         ></a
       >
@@ -69,10 +67,8 @@
         {#if ctx.step.nextButtonLabel}
           <span>{ctx.step.nextButtonLabel}</span>
         {:else}
-          <span>Gå vidare</span><LucideChevronRight
-            class="size-4"
-            aria-hidden="true"
-          />
+          <span>Gå vidare</span><span class="i-[lucide--chevron-right] size-4"
+          ></span>
         {/if}
       </a>
     {:else}

--- a/frontend/src/components/booking-form/product-count.svelte
+++ b/frontend/src/components/booking-form/product-count.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { Button } from '$components/ui/button'
 
-  import LucideMinus from 'virtual:icons/lucide/minus'
-  import LucidePlus from 'virtual:icons/lucide/plus'
   import { bookingContext } from './context'
   import type { Product } from './booking-form.svelte'
   import { inputClasses } from '$components/ui/input/input.svelte'
@@ -45,7 +43,7 @@
     class={sizes[size].button}
     onclick={() => ctx.removeProduct(productId, 1)}
     aria-label="Ta bort 1"
-    ><LucideMinus class={sizes[size].icon} aria-hidden="true" /></Button
+    ><span class="i-[lucide--minus] {sizes[size].icon}"></span></Button
   >
   <label class="sr-only" for={counterId}>Ändra antal produkter</label>
   <input
@@ -92,7 +90,7 @@
     class={sizes[size].button}
     onclick={() => ctx.addProduct(productId, 1)}
     aria-label="Lägg till 1"
-    ><LucidePlus class={sizes[size].icon} aria-hidden="true" /></Button
+    ><span class="i-[lucide--plus] {sizes[size].icon}"></span></Button
   >
 </div>
 

--- a/frontend/src/components/booking-form/products.svelte
+++ b/frontend/src/components/booking-form/products.svelte
@@ -4,10 +4,7 @@
   import { toSEKString } from '$lib/currency'
   import { bookingContext } from './context'
   import ProductCount from './product-count.svelte'
-  import LucideClock from '~icons/lucide/clock'
-  import LucideMapPin from '~icons/lucide/map-pin'
   import { draw } from 'svelte/transition'
-  import GameIconsWheat from '~icons/game-icons/wheat'
   import ConfirmDialog from './confirm-dialog.svelte'
 
   const ctx = bookingContext.get()
@@ -109,14 +106,14 @@ This could be an expandable section with a help icon or similar. Expanded by def
             <span>{shortDate.format(pickup.startTime).slice(0, -1)}</span>
           </span>
           <h2 class="flex items-center">
-            <LucideClock class="size-4 inline mr-2" aria-hidden="true" />
+            <span class="i-[lucide--clock] size-4 mr-2"></span>
             <span class="pr-1">Upphämtning:</span>
             <span>
               {timeFormat.formatRange(pickup.startTime, pickup.endTime)}</span
             >
           </h2>
           <p class="flex items-center">
-            <LucideMapPin class="size-4 inline mr-2" aria-hidden="true" />
+            <span class="i-[lucide--map-pin] size-4 mr-2"></span>
             <span>Plats: {pickup.location}</span>
           </p>
         </div>
@@ -192,9 +189,9 @@ This could be an expandable section with a help icon or similar. Expanded by def
       class="mt-8 mb-4 flex justify-center text-black/25 gap-4 items-center max-w-full"
       aria-hidden="true"
     >
-      <GameIconsWheat class="size-3" />
-      <GameIconsWheat />
-      <GameIconsWheat class="size-3" />
+      <span class="i-[game-icons--wheat] size-3"></span>
+      <span class="i-[game-icons--wheat]"></span>
+      <span class="i-[game-icons--wheat] size-3"></span>
     </div>
   </div>
 {/each}

--- a/frontend/src/components/ui/dialog/dialog-content.svelte
+++ b/frontend/src/components/ui/dialog/dialog-content.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Dialog as DialogPrimitive } from 'bits-ui'
-  import XIcon from 'virtual:icons/lucide/x'
   import type { Snippet } from 'svelte'
   import * as Dialog from './index.js'
   import { cn, type WithoutChildrenOrChild } from '$lib/utils.js'
@@ -35,7 +34,7 @@
       <DialogPrimitive.Close
         class="ring-offset-background focus:ring-ring rounded-xs focus:outline-hidden absolute end-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
       >
-        <XIcon />
+        <span class="i-[lucide--x]"></span>
         <span class="sr-only">Close</span>
       </DialogPrimitive.Close>
     {/if}

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,16 +1,2 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
-
-// NOTE: Allow using icons in both Svelte and Astro components
-// Workaround for https://github.com/unplugin/unplugin-icons/issues/253
-declare module 'virtual:icons/*' {
-  import { SvelteComponent } from 'svelte'
-  import type { SvelteHTMLElements } from 'svelte/elements'
-
-  export default class extends SvelteComponent<SvelteHTMLElements['svg']> {}
-}
-
-declare module '~icons/*' {
-  const component: (props: astroHTML.JSX.SVGAttributes) => astroHTML.JSX.Element
-  export default component
-}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2,6 +2,10 @@
 @import 'tw-animate-css';
 
 @plugin '@tailwindcss/typography';
+@plugin '@iconify/tailwind4' {
+  prefix: 'i';
+  scale: 1.2;
+}
 
 @custom-variant dark (&:is(.dark *));
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,6 @@
       "$components/*": ["./src/components/*"],
       "$layouts": ["./src/layouts"],
       "$layouts/*": ["./src/layouts/*"]
-    },
-    "types": ["unplugin-icons/types/astro"]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@iconify-json/lucide':
         specifier: ^1.2.69
         version: 1.2.69
+      '@iconify/tailwind4':
+        specifier: ^1.0.6
+        version: 1.0.6(tailwindcss@4.1.14)
       '@internationalized/date':
         specifier: ^3.10.0
         version: 3.10.0
@@ -154,17 +157,14 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
-      unplugin-icons:
-        specifier: ^22.4.2
-        version: 22.4.2(svelte@5.39.11)
 
 packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@antfu/utils@9.3.0':
-    resolution: {integrity: sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==}
+  '@antfu/utils@8.1.1':
+    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
   '@astrojs/compiler@2.13.0':
     resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
@@ -580,11 +580,16 @@ packages:
   '@iconify-json/lucide@1.2.69':
     resolution: {integrity: sha512-xOhNf74m+C+nSCObfEqYi34dXk1GMfMUcOB+gfqKY/bn0RcsPLinGfgouOvrUFEreDEFbCti7sdheTf5HESLTA==}
 
+  '@iconify/tailwind4@1.0.6':
+    resolution: {integrity: sha512-43ZXe+bC7CuE2LCgROdqbQeFYJi/J7L/k1UpSy8KDQlWVsWxPzLSWbWhlJx4uRYLOh1NRyw02YlDOgzBOFNd+A==}
+    peerDependencies:
+      tailwindcss: '>= 4'
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@iconify/utils@3.0.2':
-    resolution: {integrity: sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==}
+  '@iconify/utils@2.3.0':
+    resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2915,33 +2920,6 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
-  unplugin-icons@22.4.2:
-    resolution: {integrity: sha512-Yv15405unO67Chme0Slk0JRA/H2AiAZLK5t7ebt8/ZpTDlBfM4d4En2qD3MX2rzOSkIteQ0syIm3q8MSofeoBA==}
-    peerDependencies:
-      '@svgr/core': '>=7.0.0'
-      '@svgx/core': ^1.0.1
-      '@vue/compiler-sfc': ^3.0.2 || ^2.7.0
-      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
-      vue-template-compiler: ^2.6.12
-      vue-template-es2015-compiler: ^1.9.0
-    peerDependenciesMeta:
-      '@svgr/core':
-        optional: true
-      '@svgx/core':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      svelte:
-        optional: true
-      vue-template-compiler:
-        optional: true
-      vue-template-es2015-compiler:
-        optional: true
-
-  unplugin@2.3.10:
-    resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
-    engines: {node: '>=18.12.0'}
-
   unstorage@1.17.1:
     resolution: {integrity: sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==}
     peerDependencies:
@@ -3071,9 +3049,6 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  webpack-virtual-modules@0.6.2:
-    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
-
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
@@ -3177,7 +3152,7 @@ snapshots:
       package-manager-detector: 1.4.0
       tinyexec: 1.0.1
 
-  '@antfu/utils@9.3.0': {}
+  '@antfu/utils@8.1.1': {}
 
   '@astrojs/compiler@2.13.0': {}
 
@@ -3530,12 +3505,20 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
+  '@iconify/tailwind4@1.0.6(tailwindcss@4.1.14)':
+    dependencies:
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.3.0
+      tailwindcss: 4.1.14
+    transitivePeerDependencies:
+      - supports-color
+
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@3.0.2':
+  '@iconify/utils@2.3.0':
     dependencies:
       '@antfu/install-pkg': 1.1.0
-      '@antfu/utils': 9.3.0
+      '@antfu/utils': 8.1.1
       '@iconify/types': 2.0.0
       debug: 4.4.3
       globals: 15.15.0
@@ -6074,25 +6057,6 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  unplugin-icons@22.4.2(svelte@5.39.11):
-    dependencies:
-      '@antfu/install-pkg': 1.1.0
-      '@iconify/utils': 3.0.2
-      debug: 4.4.3
-      local-pkg: 1.1.2
-      unplugin: 2.3.10
-    optionalDependencies:
-      svelte: 5.39.11
-    transitivePeerDependencies:
-      - supports-color
-
-  unplugin@2.3.10:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      acorn: 8.15.0
-      picomatch: 4.0.3
-      webpack-virtual-modules: 0.6.2
-
   unstorage@1.17.1:
     dependencies:
       anymatch: 3.1.3
@@ -6145,8 +6109,6 @@ snapshots:
 
   web-streams-polyfill@3.3.3:
     optional: true
-
-  webpack-virtual-modules@0.6.2: {}
 
   which-pm-runs@1.1.0: {}
 


### PR DESCRIPTION
In addition to improving the performance, this approach is also much easier to work with. Just install the icon pack and plugin and start using the icons via CSS.

No Icon component imports to add, which up until now almost always happened manually since the auto imports haven't work as expected. With the CSS icons, we can just add a `span` with a `class` to get the icon.

We also don't have to add explicit `aria-hidden="true"` to all decorative icons. This could have been automated via `unplugin-icons`, but using the CSS class-based approach is still much better.

Fix #79 