### PR TITLE
Use consistently named API resources that match the backend resource

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -65,7 +65,7 @@ async function publicContext(app: FastifyInstance) {
  */
 async function authenticatedContext(app: FastifyInstance) {
   app.register(authenticationRequiredPlugin)
-  app.register(pickupOccasionRoutes, { prefix: 'api/pickups' })
+  app.register(pickupOccasionRoutes, { prefix: 'api/pickup-occasions' })
   app.register(customerRoutes, { prefix: 'api/customers' })
   app.register(orderRoutes, { prefix: 'api/orders' })
   app.register(productRoutes, { prefix: 'api/products' })

--- a/backend/src/modules/order/order.routes.test.ts
+++ b/backend/src/modules/order/order.routes.test.ts
@@ -230,7 +230,7 @@ suite('order routes', () => {
     const createdPickupResponse1: GetPickupOccasion = await app
       .inject({
         method: 'POST',
-        url: '/api/pickups/',
+        url: '/api/pickup-occasions/',
         body: pickupOccasion1,
         headers: { cookie },
       })
@@ -309,7 +309,7 @@ suite('order routes', () => {
     const createdPickupResponse2: GetPickupOccasion = await app
       .inject({
         method: 'POST',
-        url: '/api/pickups/',
+        url: '/api/pickup-occasions/',
         body: pickupOccasion2,
         headers: { cookie },
       })
@@ -372,7 +372,7 @@ suite('order routes', () => {
     const createdPickupResponse: GetPickupOccasion = await app
       .inject({
         method: 'POST',
-        url: '/api/pickups/',
+        url: '/api/pickup-occasions/',
         body: pickupOccasion,
         headers: { cookie },
       })
@@ -601,7 +601,7 @@ suite('order routes', () => {
     const createdPickupResponse: GetPickupOccasion = await app
       .inject({
         method: 'POST',
-        url: '/api/pickups/',
+        url: '/api/pickup-occasions/',
         body: pickupOccasion,
         headers: { cookie },
       })

--- a/backend/src/modules/pickup-occasion/pickup-occasion.routes.test.ts
+++ b/backend/src/modules/pickup-occasion/pickup-occasion.routes.test.ts
@@ -32,7 +32,7 @@ suite('pickup occasion routes', () => {
 
     const response = await app.inject({
       method: 'POST',
-      url: '/api/pickups/',
+      url: '/api/pickup-occasions/',
       body: pickup,
       headers: { cookie },
     })
@@ -65,7 +65,7 @@ suite('pickup occasion routes', () => {
 
     const createdPickup = await app.inject({
       method: 'POST',
-      url: '/api/pickups/',
+      url: '/api/pickup-occasions/',
       body: pickup,
       headers: { cookie },
     })
@@ -84,7 +84,7 @@ suite('pickup occasion routes', () => {
     const afterUpdate = await app
       .inject({
         method: 'PATCH',
-        url: `/api/pickups/${createdPickupDeserialized.id}`,
+        url: `/api/pickup-occasions/${createdPickupDeserialized.id}`,
         body: pickupUpdate,
         headers: { cookie },
       })
@@ -122,7 +122,7 @@ suite('pickup occasion routes', () => {
 
     const createdPickup = await app.inject({
       method: 'POST',
-      url: '/api/pickups/',
+      url: '/api/pickup-occasions/',
       body: badPickup,
       headers: { cookie },
     })
@@ -146,7 +146,7 @@ suite('pickup occasion routes', () => {
 
     const createdPickup = await app.inject({
       method: 'POST',
-      url: '/api/pickups/',
+      url: '/api/pickup-occasions/',
       body: goodPickup,
       headers: { cookie },
     })
@@ -162,7 +162,7 @@ suite('pickup occasion routes', () => {
 
     const updatedPickup = await app.inject({
       method: 'PATCH',
-      url: `/api/pickups/${createdPickup.json().id}`,
+      url: `/api/pickup-occasions/${createdPickup.json().id}`,
       body: badPickup,
       headers: { cookie },
     })

--- a/backend/src/modules/product/product.routes.test.ts
+++ b/backend/src/modules/product/product.routes.test.ts
@@ -62,7 +62,7 @@ suite('product routes', () => {
     const pickupResponse = await app
       .inject({
         method: 'POST',
-        url: '/api/pickups/',
+        url: '/api/pickup-occasions/',
         body: pickup,
         headers: { cookie },
       })
@@ -176,7 +176,7 @@ suite('product routes', () => {
 
     const pickupResponse = await app.inject({
       method: 'POST',
-      url: '/api/pickups/',
+      url: '/api/pickup-occasions/',
       body: pickup,
       headers: { cookie },
     })
@@ -300,7 +300,7 @@ suite('product routes', () => {
     const pickupResponse = await app
       .inject({
         method: 'POST',
-        url: '/api/pickups/',
+        url: '/api/pickup-occasions/',
         body: pickup,
         headers: { cookie },
       })


### PR DESCRIPTION
Renaming `/api/pickups` to `/api/pickup-occasions` to improve consistency.

Fix #134